### PR TITLE
Remove duplicated "Dexie-mongoify"

### DIFF
--- a/docs/DerivedWork.md
+++ b/docs/DerivedWork.md
@@ -17,7 +17,6 @@ Did you write something based on Dexie? Feel free to list it here.
 
 ## Known Adapters
 
-* [Dexie-mongoify](https://github.com/YuriSolovyov/Dexie-mongoify)
 * [ngDexie](https://github.com/FlussoBV/NgDexie)
 * [angular-dexie-bind](https://github.com/nhahn/angular-dexie-bind)
 


### PR DESCRIPTION
[Dexie-mongoify](https://github.com/YurySolovyov/dexie-mongoify) describes itself as addon for Dexie.js, so I removed it from the adapters listing.