### PR TITLE
Fix typo - permission.state, not permission.status

### DIFF
--- a/docs/StorageManager.md
+++ b/docs/StorageManager.md
@@ -167,7 +167,7 @@ async function tryPersistWithoutPromtingUser() {
   const permission = await navigator.permissions.query({
     name: "persistent-storage"
   });
-  if (permission.status === "granted") {
+  if (permission.state === "granted") {
     persisted = await navigator.storage.persist();
     if (persisted) {
       return "persisted";
@@ -175,7 +175,7 @@ async function tryPersistWithoutPromtingUser() {
       throw new Error("Failed to persist");
     }
   }
-  if (permission.status === "prompt") {
+  if (permission.state === "prompt") {
     return "prompt";
   }
   return "never";


### PR DESCRIPTION
Your page on the StorageManager API is great! I just noticed this small typo when trying out the example code. Reference - https://developer.mozilla.org/en-US/docs/Web/API/Permissions