### PR TITLE
Table Where Minor Doc Change

### DIFF
--- a/docs/Table/Table.bulkPut().md
+++ b/docs/Table/Table.bulkPut().md
@@ -51,8 +51,8 @@ If options argument is omitted, or options is {allKeys: false}, the return value
 
 ### Errors
 
-If some operations fail, `bulkPut()` will ignore those failures but return a rejected Promise with a 
-[Dexie.BulkError](/docs/DexieErrors/Dexie.BulkError) referencing failures. If caller does not catch that error, transaction will abort. If caller wants to ignore the failures, the `bulkPut()` operations must be caught. **NOTE: If you call `bulkPut()` outside a transaction scope and an error occur on one of the operations, the successful operations will still be persisted to DB! If this is not desired, surround your call to `bulkPut()` in a transaction and catch transaction's promise instead of the `bulkPut()` operation.**
+If some operations fail, `bulkPut()` will ignore those failures and return a rejected Promise with a
+[Dexie.BulkError](/docs/DexieErrors/Dexie.BulkError) referencing the failures. If the caller does not catch the error, the transaction will abort. If the caller wants to ignore the failures, the `bulkPut()` operations must be caught. **NOTE: If you call `bulkPut()` outside a transaction scope and an error occur on one of the operations, the successful operations will still be persisted to DB! If this is not desired, surround your call to `bulkPut()` in a transaction and catch transaction's promise instead of the `bulkPut()` operation.**
 
 ### Remarks
 

--- a/docs/Table/Table.where().md
+++ b/docs/Table/Table.where().md
@@ -59,7 +59,7 @@ Find friends named David with age between 23 and 43
 db.friends.where(["name", "age"])
   .between(["David", 23], ["David", 43], true, true)
   .each(friend => {
-      console.log("Found David, 43: " + JSON.stringify(friend));
+      console.log("Found: " + JSON.stringify(friend));
   }).catch(error => {
       console.error(error.stack || error);
   });

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 				</div>
 				<div class='col-md-4'>
 					<h2>Performant</h2>
-					<p>Dexie has an near-native performance. It's' bulk operations utilize a rarely used feature in indexedDB - to ignore success callbacks when possible.</p>
+					<p>Dexie has near-native performance. Its bulk operations utilize an often-overlooked feature in IndexedDB, ignoring success callbacks when possible.</p>
 					<p><a class='btn btn-success' href='https://jsfiddle.net/dfahlander/xf2zrL4p' role='button'>See it in action &raquo;</a></p>
 				</div>
 			</div>
@@ -111,7 +111,7 @@
 
 
 
-	
+
 
 					</code>
 				</div>
@@ -137,7 +137,7 @@
 		picture: await getBlob('camilla.png')
 	});
 
-						
+
 					</code>
 				</div>
 			</div>


### PR DESCRIPTION
While looking around, I noticed that the .each Table.where example's console log statement didn't make sense in the context of the given query. (Since it's a range of ages, not all Davids returned are 43.)

While I was at it, I figured I'd include the examples from #42  