### PR TITLE
🔨 fix syntax error and typo in API documentation

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -281,13 +281,13 @@ async function getBandsStartingWithA () {
         .toArray();
     
     // Attach resolved properies "genre" and "albums" on each band
-    // using parallell queries:
+    // using parallel queries:
     await Promise.all (bands.map (async band => {
       [band.genre, band.albums] = await Promise.all([
         db.genres.get (band.genreId),
         db.albums.where('id').anyOf(band.albumIds).toArray()
       ]);
-    });
+    }));
     
     return bands;
 }


### PR DESCRIPTION
There is a left parenthesis missing and a small typo in the comment above it. Inserting the missing paranthesis makes the example for joining tables executable.