### PR TITLE
Fix whitelist typo

### DIFF
--- a/_layouts/dexie-cloud-landing-page.html
+++ b/_layouts/dexie-cloud-landing-page.html
@@ -113,7 +113,7 @@ prismStyle: 'vscode-dark'
               will output to the console and stored in a new local file <span style="font-family: monospace;">dexie-cloud.json</span>.
             <span style="font-style: italic;">See the <a href="/cloud/docs/cli">CLI docs</a>.</span></p>
             <h3>2. Whitelist your app origin(s)</h3>
-            <pre class="command-line language-bash" data-prompt="~/my-web-app $"><code style="margin:0;">npx dexie-cloud whitelist http://localhost:8080</code></pre>
+            <pre class="command-line language-bash" data-prompt="~/my-web-app $"><code style="margin:0;">npx dexie-cloud white-list http://localhost:8080</code></pre>
             <h3>3. Install dexie-cloud-addon</h3>
             <pre class="command-line language-bash" data-prompt="~/my-web-app $"><code style="margin:0;">npm install dexie-cloud-addon</code></pre>
           </div>
@@ -162,9 +162,9 @@ prismStyle: 'vscode-dark'
             Improve your app by allowing users to <a href="/cloud/docs/access-control#example-sharable-todo-list">share things to their team or friends</a>.
           </p>
       </div>
-  
+
       <hr/>
-        
+
       {{ content }}
     </main>
 

--- a/cloud/docs/cli.md
+++ b/cloud/docs/cli.md
@@ -57,8 +57,8 @@ The user will have to authorize the request using email OTP. The system will pro
 Allow a web app to use the database.
 
 <pre>
-npx dexie-cloud whitelist
-npx dexie-cloud whitelist &lt;app origin&gt; [--delete]
+npx dexie-cloud white-list
+npx dexie-cloud white-list &lt;app origin&gt; [--delete]
 </pre>
 
 The files dexie-cloud.json and dexie-cloud.key has to be in the current or a parent directory.
@@ -70,14 +70,14 @@ The files dexie-cloud.json and dexie-cloud.key has to be in the current or a par
 #### Samples
 ```
 # Lists all whitelisted origins
-npx dexie-cloud whitelist
+npx dexie-cloud white-list
 
 # White-list new origins
-npx dexie-cloud whitelist http://localhost:8080
-npx dexie-cloud whitelist https://myapp.company.com
+npx dexie-cloud white-list http://localhost:8080
+npx dexie-cloud white-list https://myapp.company.com
 
 # Remove http://localhost:8080 from being white-listed
-npx dexie-cloud whitelist http://localhost:8080 --delete
+npx dexie-cloud white-list http://localhost:8080 --delete
 ```
 
 ## add-replica


### PR DESCRIPTION
It seems the command is `white-list` not `whitelist`.