### PR TITLE
Update the example code for Version.upgrade

### DIFF
--- a/docs/Version/Version.upgrade().md
+++ b/docs/Version/Version.upgrade().md
@@ -34,7 +34,7 @@ db.version(2).stores({
     friends: "++id,name,birthdate,sex"
 }).upgrade (trans => {
     var YEAR = 365 * 24 * 60 * 60 * 1000;
-    return trans.friends.toCollection().modify (friend => {
+    return trans.table("friends").toCollection().modify (friend => {
         friend.birthdate = new Date(Date.now() - (friend.age * YEAR));
         delete friend.age;
     });


### PR DESCRIPTION
The example code for `Version.upgrade` was giving type errors in Typescript
.
Following the example found in [this older issue](https://github.com/dexie/Dexie.js/issues/982) this updates the code to match.