### PR TITLE
Fixing some broken links in docs

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -414,7 +414,7 @@ db.transaction('rw', db.friends, db.diary, async () => {
 
 *The above snippet shows that you can also reuse code that is indeed transaction-aware, but encapsulate several such functions in an overall umbrella-transaction.*
 
-**NOTE: The code above may look like it could only execute this transaction one-at-a-time, but with thanks to [zone](https://dexie.org/docs/Promise/Promise.PSD.html) technology, this code can work in parallell with other transactions. (Dexie implements its own zone system and is not dependent on zone.js)**
+**NOTE: The code above may look like it could only execute this transaction one-at-a-time, but with thanks to [zone](/docs/Promise/Promise.PSD) technology, this code can work in parallell with other transactions. (Dexie implements its own zone system and is not dependent on zone.js)**
 
 Reference: [Dexie.transaction()](/docs/Dexie/Dexie.transaction())
 

--- a/docs/Dexie.js.md
+++ b/docs/Dexie.js.md
@@ -36,7 +36,7 @@ Dexie solves these main issues with the native IndexedDB API:
  3. [Not reactive](/docs/The-Main-Limitations-of-IndexedDB#not-reactive)
  4. [Code complexity](/docs/The-Main-Limitations-of-IndexedDB#code-complexity)
 
-Dexie.js solves these limitations and provides a neat database API. Dexie.js aims to be the first-hand choice of a IDB Wrapper Library due to its well thought-through API design, robust [error handling](/docs/API-Reference#exception-handling), [extendability](/docs/TutorialBuilding-Addons), [change tracking awareness](/docs/Tutorial/Design#change-tracking) and its extended KeyRange support ([case insensitive search](/docs/WhereClause/WhereClause.equalsIgnoreCase()), [set matches](/docs/WhereClause/WhereClause.anyOf()) and [or operations](/docs/Collection/Collection.or())).
+Dexie.js solves these limitations and provides a neat database API. Dexie.js aims to be the first-hand choice of a IDB Wrapper Library due to its well thought-through API design, robust [error handling](/docs/API-Reference#exception-handling), [extendability](/docs/Tutorial/Building-Addons), [change tracking awareness](/docs/Tutorial/Design#change-tracking) and its extended KeyRange support ([case insensitive search](/docs/WhereClause/WhereClause.equalsIgnoreCase()), [set matches](/docs/WhereClause/WhereClause.anyOf()) and [or operations](/docs/Collection/Collection.or())).
 
 #### Please Show me a Hello World Example
 

--- a/docs/Samples.md
+++ b/docs/Samples.md
@@ -85,7 +85,7 @@ title: 'Samples'
 
 #### Populate From Ajax
 
-* [Source](https://dexie.org/docs/Dexie/Dexie.on.populate.html#ajax-populate-sample)
+* [Source](/docs/Dexie/Dexie.on.populate#ajax-populate-sample)
 
 #### Open Existing Databases
 

--- a/docs/Syncable/db.syncable.connect().md
+++ b/docs/Syncable/db.syncable.connect().md
@@ -33,7 +33,7 @@ db.syncable.connect (
 
 ### Description
 
-Connect to given URL using given protocol and options. Returned Promise will resolve when [sync-protocol](/docs/Syncable/Dexie.Syncable.ISyncProtocol) has called its [onSuccess()](/docs/Syncable/Dexie.Syncable.ISyncProtocol#onsuccess--function-continuation) callback. If [sync-protocol](/docs/Syncable/Dexie.Syncable.ISyncProtocol) calls [onError()](/docs/Syncable/Dexie.Syncable.ISyncProtocol#onerror--error-again), the returned promise will reject but the underlying framework may continue to try connecting in the background. If you want to stop this, call [db.syncable.disconnect (url)](/docs/Syncable/db.syncable.disconnect()) in your catch clause.
+Connect to given URL using given protocol and options. Returned Promise will resolve when [sync-protocol](/docs/Syncable/Dexie.Syncable.ISyncProtocol) has called its [onSuccess()](/docs/Syncable/Dexie.Syncable.ISyncProtocol#onsuccess--function-continuation) callback. If [sync-protocol](/docs/Syncable/Dexie.Syncable.ISyncProtocol) calls [onError()](/docs/Syncable/Dexie.Syncable.ISyncProtocol#onerror--function-err-again), the returned promise will reject but the underlying framework may continue to try connecting in the background. If you want to stop this, call [db.syncable.disconnect (url)](/docs/Syncable/db.syncable.disconnect()) in your catch clause.
 
 Once connected, you will never have to call connect() again. Not even after a reboot. The framework will keep in sync forever with this node until a call to disconnect(), delete() happens, or if an irreparable error occurs on the node (not network down, but a fatal error).
 

--- a/docs/Table/Table.add().md
+++ b/docs/Table/Table.add().md
@@ -26,7 +26,7 @@ table.add(item, [key])
 
 Add given object to store. If an object with the same primary key already exist, the operation will fail and returned promise [catch()](/docs/Promise/Promise.catch()) callback will be called with the error object. If the operation succeeds, the returned promise [then()](/docs/Promise/Promise.then()) callback receives the result of the `add` request on the object store, the id of the inserted object.
 
-The optional second *key* argument must only be used if your table uses [non-inbound keys](https://dexie.org/docs/inbound#example-of-non-inbound-primary-key). If providing the key argument on a table with [inbound](https://dexie.org/docs/inbound) keys, the operation will fail and the returned promise will be a rejection.
+The optional second *key* argument must only be used if your table uses [outbound keys](/docs/inbound#examples-of-outbound-primary-key). If providing the key argument on a table with [inbound](/docs/inbound) keys, the operation will fail and the returned promise will be a rejection.
 
 ### See Also
 

--- a/docs/Table/Table.put().md
+++ b/docs/Table/Table.put().md
@@ -33,7 +33,7 @@ table.put(item, [key])
 
 If an object with the same primary key already exists, it will be replaced with the given object. If it does not exist, it will be added.
 
-The optional second *key* argument must only be used if your table uses [non-inbound keys](https://dexie.org/docs/inbound#example-of-non-inbound-primary-key). If providing the key argument on a table with [inbound](https://dexie.org/docs/inbound) keys, the operation will fail and the returned promise will be a rejection.
+The optional second *key* argument must only be used if your table uses [outbound keys](/docs/inbound#examples-of-outbound-primary-key). If providing the key argument on a table with [inbound](/docs/inbound) keys, the operation will fail and the returned promise will be a rejection.
 
 If the operation succeeds then the returned Promise resolves to the key under which the object was stored in the Table.
 

--- a/docs/Tutorial/Best-Practices.md
+++ b/docs/Tutorial/Best-Practices.md
@@ -90,7 +90,7 @@ function myDataOperations() {
 }
 ```
 
-But on an event handler or other root-level scope, always catch! Why?! Because you are the last one to catch it since you are NOT returning Promise! You have no caller that expects a promise and you are the sole responsible of catching and informing the user about any error. If you don't catch it anywhere, an error will end-up in the standard [unhandledrejection](https://dexie.org/docs/Promise/unhandledrejection-event.html) event.
+But on an event handler or other root-level scope, always catch! Why?! Because you are the last one to catch it since you are NOT returning Promise! You have no caller that expects a promise and you are the sole responsible of catching and informing the user about any error. If you don't catch it anywhere, an error will end-up in the standard [unhandledrejection](/docs/Promise/unhandledrejection-event) event.
 
 ```javascript
 somePromiseReturningFunc().catch((error) => {

--- a/docs/Tutorial/Understanding-the-basics.md
+++ b/docs/Tutorial/Understanding-the-basics.md
@@ -34,7 +34,7 @@ When declaring `friends: 'name, age'` the first property implicitly becomes the 
 The first time a browser hits the appdb.js code, the following happens:
 
 1. The database is created
-2. The [populate](/docs/Dexie/Dexie.on.populate.html) event is triggered to allow the developer to populate the database
+2. The [populate](/docs/Dexie/Dexie.on.populate) event is triggered to allow the developer to populate the database
 3. The db.open() promise resolves
 
 ### Second time

--- a/docs/inbound.md
+++ b/docs/inbound.md
@@ -38,7 +38,7 @@ await db.friends.bulkPut([{id: "id1", name: "Friend1"}, {id: "id2", name: "Frien
 ```
 
 
-## Example of Outbound Primary Key
+## Examples of Outbound Primary Key
 
 ```javascript
 db.version(1).stores({


### PR DESCRIPTION
Noticed some broken anchor urls (with fragment `#`), checked them (RegEx `([A-Za-z]+)#([A-Za-z]+)`) and fixed the broken.
Also brought some other into line (from absolute to relative url).