### PR TITLE
Doc: Remove extra semicolons in Collection.offset().md

### DIFF
--- a/docs/Collection/Collection.offset().md
+++ b/docs/Collection/Collection.offset().md
@@ -118,7 +118,7 @@ page = await db.friends
   .filter(fastForward(lastEntry, "id", criterionFunction))
   
   // Limit to page size:
-  .limit(PAGE_SIZE);
+  .limit(PAGE_SIZE)
   .toArray();
 
 ...
@@ -131,7 +131,7 @@ lastEntry = page[page.length-1];
 page = await db.friends
   .where('friendID').aboveOrEqual(lastEntry.lastName)
   .filter(fastForward(lastEntry, "id", criterionFunction))
-  .limit(PAGE_SIZE);
+  .limit(PAGE_SIZE)
   .toArray();
 
 


### PR DESCRIPTION
I think semicolons after limit() function are not expected in the pagination example of Collection.offset().md