### PR TITLE
Remove recommendation to install dexie@next for Svelte users

### DIFF
--- a/docs/Tutorial/Svelte.md
+++ b/docs/Tutorial/Svelte.md
@@ -30,10 +30,8 @@ Here we refer to Svelte's own [Getting Started](https://svelte.dev/blog/the-easi
 # 2. Install dexie
 
 ```
-npm install dexie@next
+npm install dexie
 ```
-
-*Svelte and SvelteKit users are recommended to install `dexie@next` which gives you version 4.x, as it contains Svelte compatible typings and SSR friendly `liveQuery()`*
 
 # 3. Create a file `db.js` (or `db.ts`)
 


### PR DESCRIPTION
As Dexie 4.0 has been released, it shouldn't be necessary to install `dexie@next` any more to get the listed features.

(I'm not sure if it would be better to edit the recommendation to advise not installing earlier versions; I've just removed the whole thing.)