### PR TITLE
Remove github markdown alert markup for notes

### DIFF
--- a/docs/Table/Table.hook('creating').md
+++ b/docs/Table/Table.hook('creating').md
@@ -3,7 +3,8 @@ layout: docs
 title: "Table.hook('creating')"
 ---
 
-> [!NOTE]
+> **NOTE**
+> 
 > Since Dexie 3.0, there is a new API superior to this hooks API: [DBCore](/docs/DBCore/DBCore). There is NO PLAN to deprecate this hooks API though, but we may extract this API to an add-on in the future.
 
 ### Syntax
@@ -158,7 +159,8 @@ db.transaction('rw', db.emails, function () {
 });
 ```
 
-> [!NOTE]
+> **NOTE**
+> 
 > Multi-valued indexes are only supported in Opera, Firefox, and Chrome. They do not work with IE so far.
 > However, it is also possible to implement it using custom views, which is implemented in FullTextSearch2.js.
 


### PR DESCRIPTION
Changing NOTES to not use the github alert markdown syntax

Checking this page after the last commit [here](https://dexie.org/docs/Table/Table.hook('creating')), I notice that the NOTE alerts do not render properly.

They render properly in github preview, [here](https://github.com/dexie/dexie-website/blob/cccd1c27fd1f462481376a7ddc8c0dda479b5539/docs/Table/Table.hook('creating').md).

There seems to be some problem with alerts rendering in some places as discussed [here](https://github.com/github/docs/issues/27919), for example.