### PR TITLE
update getting started typescript code examples

### DIFF
--- a/docs/Tutorial/React.md
+++ b/docs/Tutorial/React.md
@@ -72,28 +72,28 @@ If you use Typescript, table properties (such as `db.friends`) needs to be expli
 
 ```ts
 // db.ts
-import Dexie, { Table } from 'dexie';
+import Dexie, { type EntityTable } from 'dexie';
 
 export interface Friend {
-  id?: number;
+  id: number;
   name: string;
   age: number;
 }
 
-export class MySubClassedDexie extends Dexie {
-  // 'friends' is added by dexie when declaring the stores()
-  // We just tell the typing system this is the case
-  friends!: Table<Friend>;
+const db = new Dexie('FriendsDatabase') as Dexie & {
+  friends: EntityTable<
+    Friend,
+    'id' // primary key "id" (for the typings only)
+  >;
+};
 
-  constructor() {
-    super('myDatabase');
-    this.version(1).stores({
-      friends: '++id, name, age' // Primary key and indexed props
-    });
-  }
-}
+// Schema declaration:
+db.version(1).stores({
+  friends: '++id, name, age' // primary key "id" (for the runtime!)
+});
 
-export const db = new MySubClassedDexie();
+export type { Friend };
+export { db };
 ```
 
 # 4. Create a component that adds some data

--- a/docs/Tutorial/Svelte.md
+++ b/docs/Tutorial/Svelte.md
@@ -54,28 +54,28 @@ If you use Typescript, table properties (such as `db.friends`) needs to be expli
 
 ```ts
 // db.ts
-import Dexie, { type Table } from 'dexie';
+import Dexie, { type EntityTable } from 'dexie';
 
 export interface Friend {
-  id?: number;
+  id: number;
   name: string;
   age: number;
 }
 
-export class MySubClassedDexie extends Dexie {
-  // 'friends' is added by dexie when declaring the stores()
-  // We just tell the typing system this is the case
-  friends!: Table<Friend>; 
+const db = new Dexie('FriendsDatabase') as Dexie & {
+  friends: EntityTable<
+    Friend,
+    'id' // primary key "id" (for the typings only)
+  >;
+};
 
-  constructor() {
-    super('myDatabase');
-    this.version(1).stores({
-      friends: '++id, name, age' // Primary key and indexed props
-    });
-  }
-}
+// Schema declaration:
+db.version(1).stores({
+  friends: '++id, name, age' // primary key "id" (for the runtime!)
+});
 
-export const db = new MySubClassedDexie();
+export type { Friend };
+export { db };
 
 ```
 *See also [issue 1560](https://github.com/dexie/Dexie.js/issues/1560) containing a solution to improve typings for `liveQuery()` in case you want a more precise typings of the '$' vars.*

--- a/docs/Tutorial/Vue.md
+++ b/docs/Tutorial/Vue.md
@@ -43,28 +43,28 @@ If you use Typescript, table properties (such as `db.friends`) needs to be expli
 
 ```ts
 // db.ts
-import Dexie, { Table } from 'dexie';
+import Dexie, { type EntityTable } from 'dexie';
 
 export interface Friend {
-  id?: number;
+  id: number;
   name: string;
   age: number;
 }
 
-export class MySubClassedDexie extends Dexie {
-  // 'friends' is added by dexie when declaring the stores()
-  // We just tell the typing system this is the case
-  friends!: Table<Friend>; 
+const db = new Dexie('FriendsDatabase') as Dexie & {
+  friends: EntityTable<
+    Friend,
+    'id' // primary key "id" (for the typings only)
+  >;
+};
 
-  constructor() {
-    super('myDatabase');
-    this.version(1).stores({
-      friends: '++id, name, age' // Primary key and indexed props
-    });
-  }
-}
+// Schema declaration:
+db.version(1).stores({
+  friends: '++id, name, age' // primary key "id" (for the runtime!)
+});
 
-export const db = new MySubClassedDexie();
+export type { Friend };
+export { db };
 
 ```
 


### PR DESCRIPTION
As discussed in https://github.com/dexie/dexie-website/issues/145 updating Getting Started docs pages to match the same TypeScript approach that is used in [Typescript docs page](https://dexie.org/docs/Typescript#simplest-typescript-example).

I updated React, Vue and Svelte examples. but left Angular untouched since it's code example is different in the first place (uses `TodoList` and `TodoItem` tables instead of `Friend` and adding `populate` method) and in general it is more common to use classes in Angular to benefit from DI and so on

I omitted commend "// This prop will be used as primary key (see below)" since I'm not sure where it refers to and if this referred section is available in Getting Started pages as well