### PR TITLE
Update Table.mapToClass().md with a minor documentation fix.

### DIFF
--- a/docs/Table/Table.mapToClass().md
+++ b/docs/Table/Table.mapToClass().md
@@ -66,7 +66,7 @@ db.friends.where("name").startsWithIgnoreCase("d").each(function(friend) {
 import Dexie from 'dexie';
 
 export class FriendsDB extends Dexie {
-    friends: Dexie.Table<Friend, number>;
+    friends!: Dexie.Table<Friend, number>;
 
     constructor() {
         super("FriendsDB");


### PR DESCRIPTION
Use ! to resolve a strict-mode typescript warning.

Property 'friends' has no initializer and is not definitely assigned in the constructor. ts(2564)