### PR TITLE
Add instructions on catching errors in useLiveQuery()

### DIFF
--- a/docs/dexie-react-hooks/useLiveQuery().md
+++ b/docs/dexie-react-hooks/useLiveQuery().md
@@ -228,6 +228,9 @@ function MyComponent(id) {
 ```
 
 
+# Catching errors in useLiveQuery
+
+Use an [error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) to catch and inspect any errors happening in useLiveQuery.
 
 # Playgrounds
 


### PR DESCRIPTION
Add instructions on catching errors in useLiveQuery() using error boundaries